### PR TITLE
feature(metadata): Tool for removing duplicate metadata entries

### DIFF
--- a/actions/fix_dupe_metadata.php
+++ b/actions/fix_dupe_metadata.php
@@ -1,0 +1,56 @@
+<?php
+
+set_time_limit(0);
+
+$dbprefix = elgg_get_config('dbprefix');
+
+$type = sanitise_string(get_input('type'));
+$subtype = sanitise_string(get_input('subtype'));
+
+$md_name_id = elgg_get_metastring_id(get_input('md'));
+
+$sql = "SELECT e.guid as guid FROM {$dbprefix}entities e ";
+$sql .= "WHERE e.type = '{$type}' ";
+if ($subtype) {
+	$id = get_subtype_id($type, $subtype);
+	$sql .= "AND e.subtype = $id ";
+}
+$sql .= "AND 1 < (SELECT COUNT(md.id) FROM {$dbprefix}metadata md WHERE md.name_id = {$md_name_id} and md.entity_guid = e.guid)";
+
+$data = get_data($sql);
+
+if (!$data) {
+	echo elgg_echo('dbvalidate:dupe_metadata:success:nodupes');
+	exit;
+}
+
+foreach ($data as $result) {
+	
+	// yeah this will work best for not triggering events and stuff
+	// but damn it's slow!
+	// keeping it here in case we want to reference or tinker with it in the future
+//	$delete_sql = "DELETE md FROM {$dbprefix}metadata md ";
+//	$delete_sql .= "JOIN (SELECT MAX(md2.id) as max_id, md2.entity_guid, md2.name_id FROM {$dbprefix}metadata md2 GROUP BY md2.entity_guid, md2.name_id HAVING COUNT(*) > 1) t ON t.entity_guid = md.entity_guid AND t.name_id = md.name_id AND t.max_id != md.id ";
+//	$delete_sql .= "WHERE md.entity_guid = {$result->guid} AND md.name_id = {$md_name_id};";
+//	delete_data($delete_sql);
+	
+	$md = elgg_get_metadata([
+		'guid' => $result->guid,
+		'metadata_names' => get_input('md'),
+		'limit' => false
+	]);
+	
+	if ($md && count($md) > 1) {
+		foreach ($md as $key => $m) {
+			if ($key == (count($md) - 1)) {
+				// keep the last metadata row
+				continue;
+			}
+			
+			$m->delete();
+		}
+	}
+} 
+
+echo elgg_echo('done!');
+exit;

--- a/actions/identify_dupe_metadata.php
+++ b/actions/identify_dupe_metadata.php
@@ -1,0 +1,50 @@
+<?php
+
+set_time_limit(0);
+
+$dbprefix = elgg_get_config('dbprefix');
+
+$type = sanitise_string(get_input('type'));
+$subtype = sanitise_string(get_input('subtype'));
+
+$sql = "SELECT DISTINCT ms.string as string from {$dbprefix}metadata md ";
+$sql .= "JOIN {$dbprefix}entities e on md.entity_guid = e.guid ";
+$sql .= "JOIN {$dbprefix}metastrings ms on ms.id = md.name_id ";
+$sql .= "WHERE e.type = '{$type}' ";
+
+if ($subtype) {
+	$id = get_subtype_id(get_input('type'), get_input('subtype'));
+	$sql .= "AND e.subtype = {$id} ";
+}
+
+$sql .= "GROUP BY md.entity_guid, md.name_id HAVING COUNT(*) > 1 ";
+$sql .= "ORDER BY ms.string ASC";
+
+$data = get_data($sql);
+
+$output = '';
+foreach ($data as $result) {
+	$href = elgg_http_add_url_query_elements('action/dbvalidate/fix_dupe_metadata', [
+		'md' => $result->string,
+		'type' => $type,
+		'subtype' => $subtype
+	]);
+	
+	$output .= '<div class="clearfloat clearfix elgg-divide-bottom" style="padding-top: 10px">';
+	$output .= $result->string;
+	$output .= elgg_view('output/url', [
+		'text' => elgg_echo('dbvalidate:md:make_singular'),
+		'href' => '#',
+		'data-href' => elgg_add_action_tokens_to_url(elgg_normalize_url($href)),
+		'data-confirmText' => elgg_echo('dbvalidate:md:make_singular:confirm'),
+		'class' => 'elgg-button elgg-button-action float-alt dupe-metadata-fix'
+	]);
+	$output .= '</div>';
+}
+
+if (!$output) {
+	$output = elgg_echo('dbvalidate:md:dupe:none');
+}
+
+echo $output;
+exit;

--- a/languages/en.php
+++ b/languages/en.php
@@ -6,6 +6,7 @@
 return array(
 
 	'admin:administer_utilities:dbvalidate' => "Database cleaner",
+	'admin:administer_utilities:dupe_metadata' => "Duplicate Metadata Cleaner",
 	'dbvalidate:badusers:count' => "There are %s users without usernames",
 	'dbvalidate:badentities:count' => "There are %s bad entities without owners",
 	'dbvalidate:incomplete_entities:count' => "There are %s incomplete entities",
@@ -14,7 +15,11 @@ return array(
 	'dbvalidate:validate' => "Validate",
 	'dbvalidate:repair' => "Repair",
 	'dbvalidate:instructions' => "\"Validate\" checks for users without usernames, entities with bad owners, and incomplete entities. \"Repair\" fixes these problems. The users are assigned usernames of the form \"userxx\". Entities with bad owners are assigned to you and incomplete entities are removed.",
-
+	'dbvalidate:dupe_metadata:instructions' => "Validate checks for ElggEntity type-subtype pairs that have duplicate metadata.  In some cases duplicate metadata is ok, in other cases it can be introduced accidentally - see: https://github.com/Elgg/Elgg/issues/4268 and can cause issues (eg. a file with duplicate filestore::filestore metadata will cause fatal errors).  Once identified these can be fixed.  Changes made in here are permanent and cannot be undone.  Make sure you back up your database before doing anything else.",
+	'dbvalidate:md:make_singular' => "Make Singular",
+	'dbvalidate:md:make_singular:confirm' => "This will remove all duplicate entries for this metadata name on this type/subtype of entity, keeping only the last value.  Only do this for metadata you are SURE should only be singular.  This process could take a while on large databases.  Do you want to continue?",
+	'dbvalidate:md:dupe:none' => "No duplicate metadata was found",
+	
 	'dbvalidate:users' => 'Users',
 	'dbvalidate:entities' => 'Entities',
 	'dbvalidate:GUID' => 'GUID: ',

--- a/start.php
+++ b/start.php
@@ -15,12 +15,16 @@ elgg_register_event_handler('init', 'system', 'dbvalidate_init');
 function dbvalidate_init() {
 
 	elgg_register_admin_menu_item('administer', 'dbvalidate', 'administer_utilities');
+	elgg_register_admin_menu_item('administer', 'dupe_metadata', 'administer_utilities');
 
 	elgg_register_js('dbvalidate', 'js/dbvalidate.js', 'footer');
+	elgg_register_js('dupe_metadata', 'js/dupe_metadata.js', 'footer');
 
 	$action_path = dirname(__FILE__) . '/actions';
 	elgg_register_action('dbvalidate/validate', "$action_path/validate.php", 'admin');
 	elgg_register_action('dbvalidate/repair', "$action_path/repair.php", 'admin');
+	elgg_register_action('dbvalidate/identify_dupe_metadata', "$action_path/identify_dupe_metadata.php", 'admin');
+	elgg_register_action('dbvalidate/fix_dupe_metadata', "$action_path/fix_dupe_metadata.php", 'admin');
 }
 
 /**

--- a/views/default/admin/administer_utilities/dupe_metadata.php
+++ b/views/default/admin/administer_utilities/dupe_metadata.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Admin section for duplicate metadata cleaner
+ */
+
+elgg_load_js('dupe_metadata');
+
+echo '<p class="elgg-content-thin">';
+echo elgg_echo('dbvalidate:dupe_metadata:instructions');
+echo '</p>';
+
+$user_type = new StdClass();
+$group_type = new StdClass();
+
+$user_type->type = 'user';
+$user_type->subtype = '';
+$group_type->type = 'group';
+$group_type->subtype = '';
+
+$dbprefix = elgg_get_config('dbprefix');
+$types_subtypes = get_data("SELECT * FROM {$dbprefix}entity_subtypes");
+
+$types = array_merge([$user_type, $group_type], $types_subtypes);
+
+foreach ($types as $obj) {
+	
+	$type = $obj->type;
+	$subtype = $obj->subtype;
+	
+	$ts = $type;
+	if ($subtype) {
+		$ts .= ':' . $subtype;
+	}
+	
+	$href = elgg_normalize_url("action/dbvalidate/identify_dupe_metadata?type={$type}&subtype={$subtype}");
+	$button = elgg_view('output/url', array(
+		'text' => elgg_echo('dbvalidate:validate'),
+		'href' => '#',
+		'data-href' => elgg_add_action_tokens_to_url($href),
+		'is_action' => true,
+		'is_trusted' => true,
+		'class' => 'elgg-button elgg-button-submit dupe-metadata'
+	));
+	
+	$spinner = elgg_view('graphics/ajax_loader', array(
+		'class' => 'elgg-content-thin',
+	));
+	
+	$results = $spinner . '<div class="results">' . $button . '</div>';
+	echo elgg_view_module('main', $ts, $results);
+}

--- a/views/default/js/dupe_metadata.php
+++ b/views/default/js/dupe_metadata.php
@@ -1,0 +1,81 @@
+//<script>
+<?php
+/**
+ * Database validator JavaScript
+ */
+?>
+
+elgg.provide('elgg.dbvalidate');
+
+elgg.dbvalidate.init = function() {
+	$("a.dupe-metadata").click(elgg.dbvalidate.validate);
+	$(document).on('click', "a.dupe-metadata-fix", elgg.dbvalidate.dupeFix);
+};
+
+elgg.dbvalidate.validate = function(event) {
+	event.preventDefault();
+	
+	$(this).hide();
+	var $spinner = $(this).parents('.elgg-module').first().find('.elgg-ajax-loader');
+	var $results = $(this).parents('.results').first();
+	var url = $(this).attr('data-href');
+	$spinner.show();
+	
+	// actions in Elgg send back json so we use $.ajax
+	$.ajax({
+		type: "GET",
+		timeout: 3600000,
+		url: url,
+		dataType: "html",
+		success: function(htmlData) {
+			$spinner.hide();
+
+			if (htmlData.length > 0) {
+				$results.html(htmlData);
+			}
+		},
+		error: function(jqXHR, textStatus, error) {
+			$spinner.hide();
+			$results.html(textStatus);
+		}
+	});
+
+};
+
+elgg.dbvalidate.dupeFix = function(event) {
+	event.preventDefault();
+	
+	if ($(this).attr('disabled')) {
+		return;
+	}
+	
+	var confirm_text = $(this).attr('data-confirmText');
+	if (!confirm(confirm_text)) {
+		return false;
+	}
+	
+	var url = $(this).attr('data-href');
+	var $button = $(this);
+	var $container = $button.parents('div').first();
+	var original_text = $button.text();
+	
+	$(this).attr('disabled', true).text('Working...');
+	
+	$.ajax({
+		type: "GET",
+		timeout: 3600000,
+		url: url,
+		dataType: "html",
+		success: function(htmlData) {
+			elgg.system_message(htmlData);
+			$container.slideUp();
+		},
+		error: function(jqXHR, textStatus, error) {
+			$button.attr('disabled', false);
+			$button.text(original_text);
+			elgg.register_error(textStatus);
+		}
+	});
+};
+
+elgg.register_hook_handler('init', 'system', elgg.dbvalidate.init);


### PR DESCRIPTION
I keep having to fix data integrity issues caused by https://github.com/Elgg/Elgg/issues/4268

They happen randomly and are hard to catch.  The only time they're noticed is when something is relying a singular metadata and gets an array instead and it triggers a fatal error.  Recently this was found in a Tidypics image that had duplicate filestore metadata.

This tool gives a page where each type/subtype can be inspected to see the names of any metadata that has duplicates on at least one entity.  Each metadata name can be converted to a singular metadata for each entity.  Definitely an advanced user tool, but will save me countless hours in the future.
![screen shot 2017-02-23 at 11 06 10 pm](https://cloud.githubusercontent.com/assets/738363/23293865/8153fa8a-fa1d-11e6-94d3-42de13100a88.png)
